### PR TITLE
Add ability to delete runs in CLI/web

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -34,6 +34,7 @@ setup-hooks =
 console_scripts =
     smiley = smiley.app:main
 smiley.commands =
+    delete = smiley.commands.delete:Delete
     export = smiley.commands.export:Export
 	import = smiley.commands.export:Import
     list = smiley.commands.list:List

--- a/smiley/commands/delete.py
+++ b/smiley/commands/delete.py
@@ -1,0 +1,33 @@
+from __future__ import print_function
+import logging
+
+from cliff import command
+
+from smiley import db
+
+class Delete(command.Command):
+    """Delete a run from the database
+
+    """
+    log = logging.getLogger(__name__)
+
+    def get_parser(self, prog_name):
+        parser = super(Delete, self).get_parser(prog_name)
+        parser.add_argument(
+            '--database',
+            default='smiley.db',
+            help='filename for the database (%(default)s)',
+        )
+        parser.add_argument(
+            'run_id',
+            help='identifier for the run',
+        )
+        return parser
+
+    def take_action(self, parsed_args):
+        db_ = db.DB(parsed_args.database)
+        try:
+            db_.delete_run(parsed_args.run_id)
+            print(u"Deleted run {}".format(parsed_args.run_id))
+        except db.NoSuchRun:
+            print(u"No run found with id '{}' delete failed".format(parsed_args.run_id))

--- a/smiley/commands/delete.py
+++ b/smiley/commands/delete.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import logging
 
 from cliff import command
@@ -29,7 +28,7 @@ class Delete(command.Command):
         db_ = db.DB(parsed_args.database)
         try:
             db_.delete_run(parsed_args.run_id)
-            print(u"Deleted run {}".format(parsed_args.run_id))
+            self.log.info(u"Deleted run {}".format(parsed_args.run_id))
         except db.NoSuchRun:
-            print(u"No run found with id '{}' delete failed".format(
+            self.log.warn(u"No run found with id '{}' delete failed".format(
                 parsed_args.run_id))

--- a/smiley/commands/delete.py
+++ b/smiley/commands/delete.py
@@ -5,6 +5,7 @@ from cliff import command
 
 from smiley import db
 
+
 class Delete(command.Command):
     """Delete a run from the database
 
@@ -30,4 +31,5 @@ class Delete(command.Command):
             db_.delete_run(parsed_args.run_id)
             print(u"Deleted run {}".format(parsed_args.run_id))
         except db.NoSuchRun:
-            print(u"No run found with id '{}' delete failed".format(parsed_args.run_id))
+            print(u"No run found with id '{}' delete failed".format(
+                parsed_args.run_id))

--- a/smiley/db.py
+++ b/smiley/db.py
@@ -282,8 +282,8 @@ class DB(processor.EventProcessor):
 
     def delete_run(self, run_id):
         """Remove a run and all of its trace events from the database"""
-        #Ensure that the run exists. This will raise NoSuchRun if it doesn't.
-        run = self.get_run(run_id)
+        # Ensure that the run exists. This will raise NoSuchRun if it doesn't.
+        self.get_run(run_id)
         with transaction(self.conn) as c:
             c.execute(
                 u""" DELETE FROM trace WHERE run_id = :run_id""",

--- a/smiley/db.py
+++ b/smiley/db.py
@@ -280,6 +280,20 @@ class DB(processor.EventProcessor):
             return (_make_trace(t)
                     for t in c.fetchall())
 
+    def delete_run(self, run_id):
+        """Remove a run and all of its trace events from the database"""
+        #Ensure that the run exists. This will raise NoSuchRun if it doesn't.
+        run = self.get_run(run_id)
+        with transaction(self.conn) as c:
+            c.execute(
+                u""" DELETE FROM trace WHERE run_id = :run_id""",
+                {"run_id": run_id}
+            )
+            c.execute(
+                u"""DELETE FROM run WHERE id = :run_id""",
+                {"run_id": run_id}
+            )
+
     def cache_file_for_run(self, run_id, filename, body):
         signature_maker = hashlib.sha1()
         if isinstance(filename, six.text_type):

--- a/smiley/web/controllers/delete.py
+++ b/smiley/web/controllers/delete.py
@@ -1,0 +1,14 @@
+import logging
+
+from pecan import expose, redirect, request
+
+LOG = logging.getLogger(__name__)
+
+class DeleteController(object):
+
+    @expose(generic=True)
+    def index(self, run_id):
+        """Delete a run and redirect to the list of runs"""
+        if run_id:
+            request.db.delete_run(run_id)
+        redirect("/runs")

--- a/smiley/web/controllers/delete.py
+++ b/smiley/web/controllers/delete.py
@@ -4,6 +4,7 @@ from pecan import expose, redirect, request
 
 LOG = logging.getLogger(__name__)
 
+
 class DeleteController(object):
 
     @expose(generic=True)

--- a/smiley/web/controllers/runs.py
+++ b/smiley/web/controllers/runs.py
@@ -1,7 +1,7 @@
 import functools
 import logging
 
-from pecan import abort, expose, redirect, request
+from pecan import abort, expose, request
 from pecan.rest import RestController
 import six
 

--- a/smiley/web/controllers/runs.py
+++ b/smiley/web/controllers/runs.py
@@ -1,7 +1,7 @@
 import functools
 import logging
 
-from pecan import abort, expose, request
+from pecan import abort, expose, redirect, request
 from pecan.rest import RestController
 import six
 
@@ -10,6 +10,7 @@ from smiley.presentation import pagination
 from smiley.presentation import syntax
 from smiley.presentation import trace
 from smiley.web import nav
+from smiley.web.controllers import delete
 from smiley.web.controllers import files
 from smiley.web.controllers import stats
 from smiley.web.controllers import run_context
@@ -21,6 +22,7 @@ LOG = logging.getLogger(__name__)
 
 class RunController(RestController):
 
+    delete = delete.DeleteController()
     files = files.FileController()
     stats = stats.StatsController()
     threads = thread_controller.ThreadController()

--- a/smiley/web/templates/runs.html
+++ b/smiley/web/templates/runs.html
@@ -10,6 +10,7 @@
     <table class="table table-striped">
       <thead>
         <tr>
+          <th title="Delete">X</th>
           <th>Id</th>
           <th>Description</th>
           <th>Start Time</th>
@@ -24,6 +25,7 @@
 % else:
         <tr>
 % endif
+          <td><a href="/runs/delete?run_id=${run.id}" title="Delete">X</a></td>
           <td><a href="/runs/${run.id}">${run.id}</a></td>
           <td>${run.description}</td>
           <td>${run.start_time}</td>
@@ -34,7 +36,7 @@
           <td></td>
 % endif
         </tr>
-% endfor        
+% endfor
       </tbody>
     </table>
 


### PR DESCRIPTION
This allows a run (and all traces with that run_id) to be deleted by:

* running `smiley delete <run_id>`
* clicking the "X" link next to that run in the web view

fixes #26 