### PR TITLE
Allow to get venv from tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -17,6 +17,9 @@ commands =
 deps = flake8==2.5.4
 commands = flake8 smiley
 
+[testenv:venv]
+commands = {posargs}
+
 [testenv:docs]
 deps =
   -r{toxinidir}/requirements.txt


### PR DESCRIPTION
Allow to get venv from tox for development sessions and debug.