### PR TITLE
Fix the coverage run_python_file call

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 cliff>=1.16.0
 pyzmq>=14.3.1
-coverage>=3.7.1
+coverage>=5.3
 pecan>=0.6.1
 pygments>=1.6.0
 gprof2dot>=1.0

--- a/smiley/tracer.py
+++ b/smiley/tracer.py
@@ -253,8 +253,7 @@ class Tracer(object):
                     time.time(),
                 )
                 run_python_file(
-                    command_line[0],
-                    command_line,
+                    command_line
                 )
         except ExceptionDuringRun as err:
             # Unpack the wrapped exception


### PR DESCRIPTION
With recent versions of coverage it seems that the execfile module of coverage have been refactored and here we pull the latest version which isn't compatible with our usages, especially when we call the `run_python_file` which now accept only one argument.

These changes update our call.